### PR TITLE
Different message part sizes in Smpp::Transceiver.send_concat_mt

### DIFF
--- a/lib/smpp/transceiver.rb
+++ b/lib/smpp/transceiver.rb
@@ -49,11 +49,9 @@ class Smpp::Transceiver < Smpp::Base
         udh << sprintf("%c", parts.size)  # How many parts this message consists of
         udh << sprintf("%c", i+1)         # This is part i+1
         
-        options = {
-          :esm_class => 64,               # This message contains a UDH header.
-          :udh => udh 
-        }
-        
+        options[:esm_class] = 64 # This message contains a UDH header.
+        options[:udh] = udh
+
         pdu = Pdu::SubmitSm.new(source_addr, destination_addr, parts[i], options)
         write_pdu pdu
         

--- a/lib/smpp/transceiver.rb
+++ b/lib/smpp/transceiver.rb
@@ -36,7 +36,7 @@ class Smpp::Transceiver < Smpp::Base
       # Split the message into parts of 153 characters. (160 - 7 characters for UDH)
       parts = []
       while message.size > 0 do
-        parts << message.slice!(0..152)
+        parts << message.slice!(0..self.get_message_part_size(options))
       end
       
       0.upto(parts.size-1) do |i|
@@ -92,5 +92,18 @@ class Smpp::Transceiver < Smpp::Base
         @config[:source_npi], 
         @config[:source_address_range])
     write_pdu(pdu)
+  end
+
+  # Use data_coding to find out what message part size we can use
+  # http://en.wikipedia.org/wiki/SMS#Message_size
+  def self.get_message_part_size options
+    return 153 if options[:data_coding].nil?
+    return 153 if options[:data_coding] == 0
+    return 134 if options[:data_coding] == 3
+    return 134 if options[:data_coding] == 5
+    return 134 if options[:data_coding] == 6
+    return 134 if options[:data_coding] == 7
+    return 67  if options[:data_coding] == 8
+    return 153
   end
 end

--- a/lib/smpp/transceiver.rb
+++ b/lib/smpp/transceiver.rb
@@ -36,7 +36,7 @@ class Smpp::Transceiver < Smpp::Base
       # Split the message into parts of 153 characters. (160 - 7 characters for UDH)
       parts = []
       while message.size > 0 do
-        parts << message.slice!(0..self.get_message_part_size(options))
+        parts << message.slice!(0..Smpp::Transceiver.get_message_part_size(options))
       end
       
       0.upto(parts.size-1) do |i|

--- a/test/transceiver_test.rb
+++ b/test/transceiver_test.rb
@@ -1,0 +1,35 @@
+require "rubygems"
+require "test/unit"
+require File.expand_path(File.dirname(__FILE__) + "../../lib/smpp")
+
+class TransceiverTest < Test::Unit::TestCase
+  def test_get_message_part_size_8
+    options = {:data_coding => 8}
+    assert_equal(67, Smpp::Transceiver.get_message_part_size(options))
+  end
+  def test_get_message_part_size_0_and_1
+    options = {:data_coding => 0}
+    assert_equal(153, Smpp::Transceiver.get_message_part_size(options))
+    options = {:data_coding => 1}
+    assert_equal(153, Smpp::Transceiver.get_message_part_size(options))
+  end
+  def test_get_message_part_size_nil
+    options = {}
+    assert_equal(153, Smpp::Transceiver.get_message_part_size(options))
+  end
+  def test_get_message_part_size_other
+    options = {:data_coding => 3}
+    assert_equal(134, Smpp::Transceiver.get_message_part_size(options))
+    options = {:data_coding => 5}
+    assert_equal(134, Smpp::Transceiver.get_message_part_size(options))
+    options = {:data_coding => 6}
+    assert_equal(134, Smpp::Transceiver.get_message_part_size(options))
+    options = {:data_coding => 7}
+    assert_equal(134, Smpp::Transceiver.get_message_part_size(options))
+  end
+  def test_get_message_part_size_non_existant_data_coding
+    options = {:data_coding => 666} 
+    assert_equal(153, Smpp::Transceiver.get_message_part_size(options))
+  end
+end
+


### PR DESCRIPTION
1. fixed bug with options hash ( https://github.com/puzanov/ruby-smpp/commit/7b428a7e611c8474fe04d52c472e55533f4d459c )
2. added support for different data_codings and message part sizes ( http://en.wikipedia.org/wiki/SMS#Message_size )

Please review.

Cheers,
Oleg
