### PR TITLE
Small bugfix

### DIFF
--- a/lib/smpp/pdu/submit_multi.rb
+++ b/lib/smpp/pdu/submit_multi.rb
@@ -62,7 +62,7 @@ class Smpp::Pdu::SubmitMulti < Smpp::Pdu::Base
 
     }
 
-    formatted_array.join('\0');
+    formatted_array.join("\0");
   end
   
 end


### PR DESCRIPTION
Here's a small bugfix for the SubmitMulti PDU. What was meant to be a NULL was single quoted, so it was actually a \ followed by 0
