### PR TITLE
Callbacks for Invalid Username and Password

### DIFF
--- a/lib/smpp/base.rb
+++ b/lib/smpp/base.rb
@@ -180,11 +180,17 @@ module Smpp
           end
         when Pdu::Base::ESME_RINVPASWD
           logger.warn "Invalid password."
+          if @delegate.respond_to?(:invalid_password)
+            @delegate.invalid_password(self)
+          end
           # scheduele the connection to close, which eventually will cause the unbound() delegate 
           # method to be invoked.
           close_connection
         when Pdu::Base::ESME_RINVSYSID
           logger.warn "Invalid system id."
+          if @delegate.respond_to?(:invalid_system_id)
+            @delegate.invalid_system_id(self)
+          end
           close_connection
         else
           logger.warn "Unexpected BindTransceiverResponse. Command status: #{pdu.command_status}"


### PR DESCRIPTION
Hi,
I've made a small change to add callbacks for login errors. Our code will reconnect after a connection failure, but I find it useful to not do so in the case of a login failure causing the disconnect.

Thanks,
Mal
