### PR TITLE
Remove unused require 'iconv'

### DIFF
--- a/lib/smpp/base.rb
+++ b/lib/smpp/base.rb
@@ -1,5 +1,4 @@
 require 'timeout'
-require 'iconv'
 require 'scanf'
 require 'monitor'
 require 'eventmachine'


### PR DESCRIPTION
To remove deprecation warning for 1.9.x ruby (iconv will be deprecated in the future, use String#encode instead)
