### PR TITLE
some exceptions fixed

### DIFF
--- a/lib/smpp/pdu/base.rb
+++ b/lib/smpp/pdu/base.rb
@@ -88,7 +88,7 @@ module Smpp::Pdu
       @command_status = command_status
       @body = body
       @sequence_number = seq
-      @data = fixed_int(length) + fixed_int(command_id) + fixed_int(command_status) + fixed_int(seq) + body   
+      @data = fixed_int(length) + fixed_int(command_id) + fixed_int(command_status) + fixed_int(seq) + body.force_encoding("ascii-8bit")
     end      
 
     def logger

--- a/lib/smpp/transceiver.rb
+++ b/lib/smpp/transceiver.rb
@@ -42,7 +42,7 @@ class Smpp::Transceiver < Smpp::Base
         end
       else
         bytes = message.bytes.to_a
-        0.upto((bytes.length / 134.0).ceil) do |part|
+        0.upto(bytes.length / 134) do |part|
           parts << bytes.slice(part * 134, 134).pack("C*")
         end
       end

--- a/lib/smpp/transceiver.rb
+++ b/lib/smpp/transceiver.rb
@@ -45,7 +45,7 @@ class Smpp::Transceiver < Smpp::Base
 
         #TODO Figure out why this needs to be an int here, it's a string elsewhere
         # so, we can use object_id because it`s always integer
-        udh << sprintf("%c", message_id.object_id)  # The ID for the entire concatenated message
+        udh << sprintf("%c", message_id.object_id & 0xFF)  # The ID for the entire concatenated message
 
         udh << sprintf("%c", parts.size)  # How many parts this message consists of
         udh << sprintf("%c", i+1)         # This is part i+1

--- a/lib/smpp/transceiver.rb
+++ b/lib/smpp/transceiver.rb
@@ -44,7 +44,8 @@ class Smpp::Transceiver < Smpp::Base
         udh << sprintf("%c%c", 0, 3)      # This is a concatenated message 
 
         #TODO Figure out why this needs to be an int here, it's a string elsewhere
-        udh << sprintf("%c", message_id)  # The ID for the entire concatenated message
+        # so, we can use object_id because it`s always integer
+        udh << sprintf("%c", message_id.object_id)  # The ID for the entire concatenated message
 
         udh << sprintf("%c", parts.size)  # How many parts this message consists of
         udh << sprintf("%c", i+1)         # This is part i+1

--- a/lib/smpp/transceiver.rb
+++ b/lib/smpp/transceiver.rb
@@ -42,7 +42,7 @@ class Smpp::Transceiver < Smpp::Base
         end
       else
         bytes = message.bytes.to_a
-        0.upto((bytes / 134.0).ceil) do |part|
+        0.upto((bytes.length / 134.0).ceil) do |part|
           parts << bytes.slice(part * 134, 134).pack("C*")
         end
       end

--- a/lib/smpp/transceiver.rb
+++ b/lib/smpp/transceiver.rb
@@ -31,12 +31,20 @@ class Smpp::Transceiver < Smpp::Base
 
   # Send a concatenated message with a body of > 160 characters as multiple messages.
   def send_concat_mt(message_id, source_addr, destination_addr, message, options = {})
+    message = message.dup
     logger.debug "Sending concatenated MT: #{message}"
     if @state == :bound
       # Split the message into parts of 153 characters. (160 - 7 characters for UDH)
       parts = []
-      while message.size > 0 do
-        parts << message.slice!(0..Smpp::Transceiver.get_message_part_size(options))
+      if options[:data_coding] != 8
+        while message.size > 0 do
+          parts << message.slice!(0..Smpp::Transceiver.get_message_part_size(options))
+        end
+      else
+        bytes = message.bytes.to_a
+        0.upto((bytes / 134.0).ceil) do |part|
+          parts << bytes.slice(part * 134, 134).pack("C*")
+        end
       end
       
       0.upto(parts.size-1) do |i|


### PR DESCRIPTION
1. incompatible encoding exception (US-ASCII vs ASCII-8BIT) was raised in Smpp::Pdu::Base#initialize while reading some PDUs from SMPP bytestream. it's fixed just by String#force_encoding to ASCII-8BIT.
2. message_id was limited to be integer in Smpp::Tranciever#send_concat_mt. moreover, it's just ruined UDH structure if message_id was >255 and raised an exception if message_id was greater than unicode char range. it's fixed by using object_id of message_id (I don't think that internal ids must be integer anyway; I use hashes in my app, for example) and cutting it down to one octet ( & 0xFF).
