### PR TITLE
Add unicode support for SubmitSm

### DIFF
--- a/lib/smpp/pdu/base.rb
+++ b/lib/smpp/pdu/base.rb
@@ -88,7 +88,9 @@ module Smpp::Pdu
       @command_status = command_status
       @body = body
       @sequence_number = seq
-      @data = fixed_int(length) + fixed_int(command_id) + fixed_int(command_status) + fixed_int(seq) + body   
+      
+      header = [length, command_id, command_status, seq].pack("NNNN")
+      @data = header + body 
     end      
 
     def logger

--- a/lib/smpp/pdu/submit_sm.rb
+++ b/lib/smpp/pdu/submit_sm.rb
@@ -6,10 +6,8 @@ class Smpp::Pdu::SubmitSm < Smpp::Pdu::Base
               :validity_period, :registered_delivery, :replace_if_present_flag, :data_coding, 
               :sm_default_msg_id, :sm_length, :udh, :short_message, :optional_parameters
 
-  
-  # Note: short_message (the SMS body) must be in iso-8859-1 format
+
   def initialize(source_addr, destination_addr, short_message, options={}, seq = nil)
-     
     @msg_body = short_message
     
     @udh = options[:udh]      
@@ -30,6 +28,12 @@ class Smpp::Pdu::SubmitSm < Smpp::Pdu::Base
     @data_coding             = options[:data_coding]?options[:data_coding]:3 # iso-8859-1
     @sm_default_msg_id       = options[:sm_default_msg_id]?options[:sm_default_msg_id]:0
     @short_message           = short_message
+    
+    # Add UCS2 support
+    if @data_coding == 8
+      @short_message = @short_message.encode("UTF-16BE").force_encoding("BINARY")
+    end
+        
     payload                  = @udh ? @udh + @short_message : @short_message 
     @sm_length               = payload.length
     


### PR DESCRIPTION
I wanted to send SMS in unicode using data_coding 8, but unfortunately i can't get message with right encoding. There is a patch which fixes this problem.
