### PR TITLE
Fix "wrong number of arguments" error

### DIFF
--- a/lib/smpp/base.rb
+++ b/lib/smpp/base.rb
@@ -12,7 +12,7 @@ module Smpp
     # :bound or :unbound
     attr_accessor :state
 
-    def initialize(config)
+    def initialize(config, delegate)
       @state = :unbound
       @config = config
       @data = ""

--- a/lib/smpp/base.rb
+++ b/lib/smpp/base.rb
@@ -12,7 +12,7 @@ module Smpp
     # :bound or :unbound
     attr_accessor :state
 
-    def initialize(config, delegate = 0)
+    def initialize(config)
       @state = :unbound
       @config = config
       @data = ""

--- a/lib/smpp/base.rb
+++ b/lib/smpp/base.rb
@@ -12,7 +12,7 @@ module Smpp
     # :bound or :unbound
     attr_accessor :state
 
-    def initialize(config, delegate = nil)
+    def initialize(config, delegate = 0)
       @state = :unbound
       @config = config
       @data = ""

--- a/lib/smpp/base.rb
+++ b/lib/smpp/base.rb
@@ -12,7 +12,7 @@ module Smpp
     # :bound or :unbound
     attr_accessor :state
 
-    def initialize(config, delegate)
+    def initialize(config, delegate = nil)
       @state = :unbound
       @config = config
       @data = ""

--- a/lib/smpp/server.rb
+++ b/lib/smpp/server.rb
@@ -13,7 +13,7 @@ class Smpp::Server < Smpp::Base
   # a proc to invoke for delivery reports,
   # and optionally a hash-like storage for pending delivery reports.
   def initialize(config, received_messages = [], sent_messages = [])
-    super(config)
+    super(config, nil)
     @state = :unbound
     @received_messages = received_messages
     @sent_messages = sent_messages


### PR DESCRIPTION
Fix "wrong number of arguments" error for Smpp::Server using.

In Smpp::Server.initialize you call:
super(config)
but Smpp::Base.initialize has 2 arguments:
def initialize(config, delegate)
