### PR TITLE
Sms can be longer than 127 characters

### DIFF
--- a/config/environment.rb
+++ b/config/environment.rb
@@ -1,2 +1,3 @@
+# -*- encoding : utf-8 -*-
 require "rubygems"
 require "bundler/setup"

--- a/examples/sample_gateway.rb
+++ b/examples/sample_gateway.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 #!/usr/bin/env ruby
 
 # Sample SMS gateway that can receive MOs (mobile originated messages) and

--- a/examples/sample_smsc.rb
+++ b/examples/sample_smsc.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 #!/usr/bin/env ruby
 
 # Sample SMPP SMS Gateway. 

--- a/lib/smpp.rb
+++ b/lib/smpp.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 # SMPP v3.4 subset implementation.
 # SMPP is a short message peer-to-peer protocol typically used to communicate
 # with SMS Centers (SMSCs) over TCP/IP.

--- a/lib/smpp/base.rb
+++ b/lib/smpp/base.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 require 'timeout'
 require 'scanf'
 require 'monitor'

--- a/lib/smpp/encoding/utf8_encoder.rb
+++ b/lib/smpp/encoding/utf8_encoder.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 require 'iconv'
 
 module Smpp

--- a/lib/smpp/optional_parameter.rb
+++ b/lib/smpp/optional_parameter.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 class Smpp::OptionalParameter
 
   attr_reader :tag, :value

--- a/lib/smpp/pdu/base.rb
+++ b/lib/smpp/pdu/base.rb
@@ -91,7 +91,7 @@ module Smpp::Pdu
       if RUBY_VERSION < "1.9"
         @data = fixed_int(length) + fixed_int(command_id) + fixed_int(command_status) + fixed_int(seq) + body
       else
-        @data =  (fixed_int(length) + fixed_int(command_id) + fixed_int(command_status) + fixed_int(seq)).force_encoding("BINARY") + body.force_encoding("BINARY")
+        @data =  (fixed_int(length) + fixed_int(command_id) + fixed_int(command_status) + fixed_int(seq)).force_encoding("UTF-8") + body.force_encoding("UTF-8")
       end
     end      
 

--- a/lib/smpp/pdu/base.rb
+++ b/lib/smpp/pdu/base.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 # PDUs are the protcol base units in SMPP
 module Smpp::Pdu
   class Base

--- a/lib/smpp/pdu/base.rb
+++ b/lib/smpp/pdu/base.rb
@@ -88,7 +88,7 @@ module Smpp::Pdu
       @command_status = command_status
       @body = body
       @sequence_number = seq
-      if RUBY_VERSION < 1.9
+      if RUBY_VERSION < "1.9"
         @data = fixed_int(length) + fixed_int(command_id) + fixed_int(command_status) + fixed_int(seq) + body
       else
         @data =  (fixed_int(length) + fixed_int(command_id) + fixed_int(command_status) + fixed_int(seq)).force_encoding("BINARY") + body.force_encoding("BINARY")

--- a/lib/smpp/pdu/base.rb
+++ b/lib/smpp/pdu/base.rb
@@ -88,7 +88,11 @@ module Smpp::Pdu
       @command_status = command_status
       @body = body
       @sequence_number = seq
-      @data = fixed_int(length) + fixed_int(command_id) + fixed_int(command_status) + fixed_int(seq) + body   
+      if RUBY_VERSION < 1.9
+        @data = fixed_int(length) + fixed_int(command_id) + fixed_int(command_status) + fixed_int(seq) + body
+      else
+        @data =  (fixed_int(length) + fixed_int(command_id) + fixed_int(command_status) + fixed_int(seq)).force_encoding("BINARY") + body.force_encoding("BINARY")
+      end
     end      
 
     def logger

--- a/lib/smpp/pdu/bind_base.rb
+++ b/lib/smpp/pdu/bind_base.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 # this class serves as the base for all the bind* commands.
 # since the command format remains the same for all bind commands, 
 # sub classes just change the @@command_id

--- a/lib/smpp/pdu/bind_receiver.rb
+++ b/lib/smpp/pdu/bind_receiver.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 class Smpp::Pdu::BindReceiver < Smpp::Pdu::BindBase
   @command_id = BIND_RECEIVER
   handles_cmd BIND_RECEIVER

--- a/lib/smpp/pdu/bind_receiver_response.rb
+++ b/lib/smpp/pdu/bind_receiver_response.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 class Smpp::Pdu::BindReceiverResponse < Smpp::Pdu::BindRespBase
   @command_id = BIND_RECEIVER_RESP
   handles_cmd BIND_RECEIVER_RESP

--- a/lib/smpp/pdu/bind_resp_base.rb
+++ b/lib/smpp/pdu/bind_resp_base.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 class Smpp::Pdu::BindRespBase < Smpp::Pdu::Base
   class << self; attr_accessor :command_id ; end
   attr_accessor :system_id

--- a/lib/smpp/pdu/bind_transceiver.rb
+++ b/lib/smpp/pdu/bind_transceiver.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 class Smpp::Pdu::BindTransceiver < Smpp::Pdu::BindBase
   @command_id = BIND_TRANSCEIVER
   handles_cmd BIND_TRANSCEIVER

--- a/lib/smpp/pdu/bind_transceiver_response.rb
+++ b/lib/smpp/pdu/bind_transceiver_response.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 class Smpp::Pdu::BindTransceiverResponse < Smpp::Pdu::BindRespBase
   @command_id = BIND_TRANSCEIVER_RESP
   handles_cmd BIND_TRANSCEIVER_RESP

--- a/lib/smpp/pdu/bind_transmitter.rb
+++ b/lib/smpp/pdu/bind_transmitter.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 class Smpp::Pdu::BindTransmitter < Smpp::Pdu::BindBase
   @command_id = BIND_TRANSMITTER
   handles_cmd BIND_TRANSMITTER

--- a/lib/smpp/pdu/bind_transmitter_response.rb
+++ b/lib/smpp/pdu/bind_transmitter_response.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 class Smpp::Pdu::BindTransmitterResponse < Smpp::Pdu::BindRespBase
   @command_id = BIND_TRANSMITTER_RESP
   handles_cmd BIND_TRANSMITTER_RESP

--- a/lib/smpp/pdu/deliver_sm.rb
+++ b/lib/smpp/pdu/deliver_sm.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 
 # Received for MO message or delivery notification
 class Smpp::Pdu::DeliverSm < Smpp::Pdu::Base 

--- a/lib/smpp/pdu/deliver_sm_response.rb
+++ b/lib/smpp/pdu/deliver_sm_response.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 class Smpp::Pdu::DeliverSmResponse < Smpp::Pdu::Base
   handles_cmd DELIVER_SM_RESP
 

--- a/lib/smpp/pdu/enquire_link.rb
+++ b/lib/smpp/pdu/enquire_link.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 class Smpp::Pdu::EnquireLink < Smpp::Pdu::Base
   handles_cmd ENQUIRE_LINK
 

--- a/lib/smpp/pdu/enquire_link_response.rb
+++ b/lib/smpp/pdu/enquire_link_response.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 class Smpp::Pdu::EnquireLinkResponse < Smpp::Pdu::Base
   handles_cmd ENQUIRE_LINK_RESP
 

--- a/lib/smpp/pdu/generic_nack.rb
+++ b/lib/smpp/pdu/generic_nack.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 # signals invalid message header
 class Smpp::Pdu::GenericNack < Smpp::Pdu::Base
   handles_cmd GENERIC_NACK

--- a/lib/smpp/pdu/submit_multi.rb
+++ b/lib/smpp/pdu/submit_multi.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 # Sending an MT message to multiple addresses
 # Author: Abhishek Parolkar, (abhishek[at]parolkar.com)
 #TODO: Implement from_wire_data for this pdu class.

--- a/lib/smpp/pdu/submit_multi_response.rb
+++ b/lib/smpp/pdu/submit_multi_response.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 # Recieving response for an MT message sent to multiple addresses
 # Author: Abhishek Parolkar, (abhishek[at]parolkar.com)
 class Smpp::Pdu::SubmitMultiResponse < Smpp::Pdu::Base

--- a/lib/smpp/pdu/submit_sm.rb
+++ b/lib/smpp/pdu/submit_sm.rb
@@ -1,3 +1,5 @@
+# -*- encoding : utf-8 -*-
+
 # Sending an MT message
 class Smpp::Pdu::SubmitSm < Smpp::Pdu::Base
   handles_cmd SUBMIT_SM

--- a/lib/smpp/pdu/submit_sm_response.rb
+++ b/lib/smpp/pdu/submit_sm_response.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 class Smpp::Pdu::SubmitSmResponse < Smpp::Pdu::Base
   handles_cmd SUBMIT_SM_RESP
 

--- a/lib/smpp/pdu/unbind.rb
+++ b/lib/smpp/pdu/unbind.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 class Smpp::Pdu::Unbind < Smpp::Pdu::Base
   handles_cmd UNBIND
 

--- a/lib/smpp/pdu/unbind_response.rb
+++ b/lib/smpp/pdu/unbind_response.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 class Smpp::Pdu::UnbindResponse < Smpp::Pdu::Base
   handles_cmd UNBIND_RESP
 

--- a/lib/smpp/receiver.rb
+++ b/lib/smpp/receiver.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 # The SMPP Receiver maintains a unidirectional connection to an SMSC.
 # Provide a config hash with connection options to get started. 
 # See the sample_gateway.rb for examples of config values.

--- a/lib/smpp/server.rb
+++ b/lib/smpp/server.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 # --------
 # This is experimental stuff submitted by taryn@taryneast.org
 # --------

--- a/lib/smpp/transceiver.rb
+++ b/lib/smpp/transceiver.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 # The SMPP Transceiver maintains a bidirectional connection to an SMSC.
 # Provide a config hash with connection options to get started. 
 # See the sample_gateway.rb for examples of config values.

--- a/lib/smpp/transmitter.rb
+++ b/lib/smpp/transmitter.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 # The SMPP Transmitter maintains a unidirectional connection to an SMSC.
 # Provide a config hash with connection options to get started.
 # See the sample_gateway.rb for examples of config values.

--- a/lib/smpp/version.rb
+++ b/lib/smpp/version.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 module Smpp
   VERSION = "0.6.0"
 end

--- a/lib/sms.rb
+++ b/lib/sms.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 # Basic SMS class for sample gateway
 
 class Sms

--- a/test/delegate.rb
+++ b/test/delegate.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 # the delagate receives callbacks when interesting things happen on the connection
 class Delegate
 

--- a/test/encoding_test.rb
+++ b/test/encoding_test.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 require 'rubygems'
 require 'test/unit'
 require 'smpp/encoding/utf8_encoder'

--- a/test/optional_parameter_test.rb
+++ b/test/optional_parameter_test.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 require 'rubygems'
 require 'test/unit'
 require 'smpp'

--- a/test/pdu_parsing_test.rb
+++ b/test/pdu_parsing_test.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 require 'rubygems'
 require 'test/unit'
 require File.expand_path(File.dirname(__FILE__) + "../../lib/smpp")

--- a/test/receiver_test.rb
+++ b/test/receiver_test.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 require 'rubygems'
 require 'test/unit'
 require 'smpp'

--- a/test/responsive_delegate.rb
+++ b/test/responsive_delegate.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 #TODO This should be made prettier with mocha
 class ResponsiveDelegate
   attr_reader :seq, :event_counter

--- a/test/server.rb
+++ b/test/server.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 # a server which immediately requests the client to unbind
 module Server
   def self.config

--- a/test/smpp_test.rb
+++ b/test/smpp_test.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 require 'rubygems'
 require 'test/unit'
 require 'smpp'

--- a/test/submit_sm_test.rb
+++ b/test/submit_sm_test.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 require 'rubygems'
 require 'test/unit'
 require 'smpp'

--- a/test/transceiver_test.rb
+++ b/test/transceiver_test.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 require "rubygems"
 require "test/unit"
 require File.expand_path(File.dirname(__FILE__) + "../../lib/smpp")


### PR DESCRIPTION
Here is a fix that allows longer sms than 127 characters in >=ruby-1.9.
