### PR TITLE
Fix Encoding::CompatibilityError when sending in UCS-2

### DIFF
--- a/lib/smpp/pdu/submit_sm.rb
+++ b/lib/smpp/pdu/submit_sm.rb
@@ -32,7 +32,7 @@ class Smpp::Pdu::SubmitSm < Smpp::Pdu::Base
     @data_coding             = options[:data_coding]?options[:data_coding]:3 # iso-8859-1
     @sm_default_msg_id       = options[:sm_default_msg_id]?options[:sm_default_msg_id]:0
     @short_message           = short_message
-    payload                  = @udh ? @udh + @short_message : @short_message
+    payload                  = @udh ? @udh + @short_message.force_encoding('UTF-8') : @short_message
     @sm_length               = payload.length
 
     @optional_parameters     = options[:optional_parameters]
@@ -55,7 +55,7 @@ class Smpp::Pdu::SubmitSm < Smpp::Pdu::Base
   def to_human
     # convert header (4 bytes) to array of 4-byte ints
     a = @data.to_s.unpack('N4')
-    sprintf("(%22s) len=%3d cmd=%8s status=%1d seq=%03d (%s)", self.class.to_s[11..-1], a[0], a[1].to_s(16), a[2], a[3], @msg_body[0..30])
+    sprintf("(%22s) len=%3d cmd=%8s status=%1d seq=%03d (%s)", self.class.to_s[11..-1], a[0], a[1].to_s(16), a[2], a[3], @msg_body[0..30].encode('UTF-8'))
   end
 
   def self.from_wire_data(seq, status, body)

--- a/lib/smpp/transceiver.rb
+++ b/lib/smpp/transceiver.rb
@@ -33,7 +33,7 @@ class Smpp::Transceiver < Smpp::Base
 
   # Send a concatenated message with a body of > 160 characters as multiple messages.
   def send_concat_mt(message_id, source_addr, destination_addr, message, options = {})
-    logger.debug "Sending concatenated MT: #{message}"
+    logger.debug "Sending concatenated MT: #{message.encode('UTF-8')}"
     if @state == :bound
       # Split the message into parts of 153 characters. (160 - 7 characters for UDH)
       parts = []


### PR DESCRIPTION
Hello :)

Thank you for the gem.

I had to send SMS messages in UCS-2 encoding. That's `UCS-2BE` in Ruby. I had to make these changes to the gem for it to work and not to raise `Encoding::CompatibilityError`.

I'm not sure if this is the right way to do it. If I need to make more / better changes, please let me know.
